### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/Labs/Lab01-configure-vms.md
+++ b/Instructions/Labs/Lab01-configure-vms.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Exercise 01: Configure an Azure Linux virtual machine'
-    module: 'Guided Project: Deploy and administer Linux virtual machines'
+  title: 'Exercise 01: Configure an Azure Linux virtual machine'
+  module: 'Guided Project: Deploy and administer Linux virtual machines'
+  description: In this task, you will create and deploy a Linux virtual machine using the portal.
+  duration: 45 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Exercise 01: Configure an Azure Linux virtual machine 

--- a/Instructions/Labs/Lab01-configure-vms.md
+++ b/Instructions/Labs/Lab01-configure-vms.md
@@ -2,12 +2,14 @@
 lab:
   title: 'Exercise 01: Configure an Azure Linux virtual machine'
   module: 'Guided Project: Deploy and administer Linux virtual machines'
-  description: In this task, you will create and deploy a Linux virtual machine using the portal.
+  description: Create and configure a Linux virtual machine.
   duration: 45 minutes
-  level: 500
+  level: 400
   islab: true
   primarytopics:
     - Azure
+    - Linux 
+    - Virtual machines
 ---
 
 # Exercise 01: Configure an Azure Linux virtual machine 

--- a/Instructions/Labs/Lab02-monitor-vms.md
+++ b/Instructions/Labs/Lab02-monitor-vms.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Exercise 02: Monitor an Azure Linux virtual machine'
-    module: 'Guided Project: Deploy and administer Linux virtual machines'
+  title: 'Exercise 02: Monitor an Azure Linux virtual machine'
+  module: 'Guided Project: Deploy and administer Linux virtual machines'
+  description: In this task, you will use a template to deploy a virtual machine.
+  duration: 45 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Exercise 02: Monitor an Azure Linux virtual machine

--- a/Instructions/Labs/Lab02-monitor-vms.md
+++ b/Instructions/Labs/Lab02-monitor-vms.md
@@ -2,12 +2,15 @@
 lab:
   title: 'Exercise 02: Monitor an Azure Linux virtual machine'
   module: 'Guided Project: Deploy and administer Linux virtual machines'
-  description: In this task, you will use a template to deploy a virtual machine.
+  description: Create and monitor a Linux virtual machine. 
   duration: 45 minutes
   level: 300
   islab: true
   primarytopics:
     - Azure
+    - Linux
+    - Virtual machine
+    - Azure Monitor
 ---
 
 # Exercise 02: Monitor an Azure Linux virtual machine

--- a/Instructions/Labs/Lab03-storage-vms.md
+++ b/Instructions/Labs/Lab03-storage-vms.md
@@ -2,12 +2,15 @@
 lab:
   title: 'Exercise 03: Access storage for an Azure Linux virtual machine'
   module: 'Guided Project: Deploy and administer Linux virtual machines'
-  description: In this task, you will create a storage account and file share. You will then give the virtual machine access to the file share and connect to the file share.
+  description: Create and configure access from a Linux virtual machine to Azure storage. 
   duration: 45 minutes
-  level: 500
+  level: 400
   islab: true
   primarytopics:
     - Azure
+    - Linux
+    - Virtual machines
+    - Storage access
 ---
 
 # Exercise 03: Access storage for an Azure Linux virtual machine

--- a/Instructions/Labs/Lab03-storage-vms.md
+++ b/Instructions/Labs/Lab03-storage-vms.md
@@ -1,9 +1,14 @@
 ---
 lab:
-    title: 'Exercise 03: Access storage for an Azure Linux virtual machine'
-    module: 'Guided Project: Deploy and administer Linux virtual machines'
+  title: 'Exercise 03: Access storage for an Azure Linux virtual machine'
+  module: 'Guided Project: Deploy and administer Linux virtual machines'
+  description: In this task, you will create a storage account and file share. You will then give the virtual machine access to the file share and connect to the file share.
+  duration: 45 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
 ---
-
 
 # Exercise 03: Access storage for an Azure Linux virtual machine
 

--- a/Instructions/Labs/Lab04-backup-vms.md
+++ b/Instructions/Labs/Lab04-backup-vms.md
@@ -3,7 +3,7 @@ lab:
   title: 'Exercise 04: Back up Azure Linux virtual machines'
   module: 'Guided Project: Deploy and administer Linux virtual machines'
   description: Create a Linux virtual machine and configure backups. 
-  duration: 5 minutes
+  duration: 30 minutes
   level: 300
   islab: true
   primarytopics:

--- a/Instructions/Labs/Lab04-backup-vms.md
+++ b/Instructions/Labs/Lab04-backup-vms.md
@@ -2,12 +2,14 @@
 lab:
   title: 'Exercise 04: Back up Azure Linux virtual machines'
   module: 'Guided Project: Deploy and administer Linux virtual machines'
-  description: In this task, you will implement Azure virtual machine level backup. As part of a VM backup, you will define a backup and retention policy.
+  description: Create a Linux virtual machine and configure backups. 
   duration: 5 minutes
   level: 300
   islab: true
   primarytopics:
     - Azure
+    - Virtual Machines
+    - Backup
 ---
 
 # Exercise 04: Back up Azure Linux virtual machines

--- a/Instructions/Labs/Lab04-backup-vms.md
+++ b/Instructions/Labs/Lab04-backup-vms.md
@@ -1,8 +1,15 @@
 ---
 lab:
-    title: 'Exercise 04: Back up Azure Linux virtual machines'
-    module: 'Guided Project: Deploy and administer Linux virtual machines'
+  title: 'Exercise 04: Back up Azure Linux virtual machines'
+  module: 'Guided Project: Deploy and administer Linux virtual machines'
+  description: In this task, you will implement Azure virtual machine level backup. As part of a VM backup, you will define a backup and retention policy.
+  duration: 5 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
+
 # Exercise 04: Back up Azure Linux virtual machines
 
 ## Lab requirements    


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/Labs/Lab01-configure-vms.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab02-monitor-vms.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab03-storage-vms.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab04-backup-vms.md` (description,duration,level,islab,primarytopics)
