### PR TITLE
Update in Lab01 & Lab02

### DIFF
--- a/Instructions/Labs/Lab01-configure-vms.md
+++ b/Instructions/Labs/Lab01-configure-vms.md
@@ -61,7 +61,7 @@ In this task, you will create and deploy a Linux virtual machine using the porta
     | Availability options | **No infrastructure redundancy required** |
     | Security type | **Standard** (review your other choices) |
     | Image | **Ubuntu Server 24.04 LTS - x64 Gen2** (use the drop-down to view other options) |
-    | Size | **Standard_FX2ms_v2** (use **See all sizes** to view the CPU and memory) |
+    | Size | **Standard_D2s_v3** (use **See all sizes** to view the CPU and memory) |
     | Authentication type | **SSH public key** (notice you could use a password) |
     | Username | `adminuser` |
     | SSH public key source | **Generate new key pair** (notice your choices to use an existing key) |

--- a/Instructions/Labs/Lab01-configure-vms.md
+++ b/Instructions/Labs/Lab01-configure-vms.md
@@ -60,8 +60,8 @@ In this task, you will create and deploy a Linux virtual machine using the porta
     | Region | **(US) East US** |
     | Availability options | **No infrastructure redundancy required** |
     | Security type | **Standard** (review your other choices) |
-    | Image | **Ubuntu Server 20.04 LTS - x64 Gen2** (use the drop-down to view other options) |
-    | Size | **Standard_D2s_v3** (use **See all sizes** to view the CPU and memory) |
+    | Image | **Ubuntu Server 24.04 LTS - x64 Gen2** (use the drop-down to view other options) |
+    | Size | **Standard_FX2ms_v2** (use **See all sizes** to view the CPU and memory) |
     | Authentication type | **SSH public key** (notice you could use a password) |
     | Username | `adminuser` |
     | SSH public key source | **Generate new key pair** (notice your choices to use an existing key) |

--- a/Instructions/Labs/Lab02-monitor-vms.md
+++ b/Instructions/Labs/Lab02-monitor-vms.md
@@ -94,7 +94,7 @@ In this task, you will enable Insights for a virtual machine.
 
 1. On the **Unlock enhanced monitoring** banner, select **Configure**.
 
-1. On the **Capabilities** tab, review the default settings. If prompted, accept the default **Azure Monitor workspace** and **Log Analytics workspace** values.
+1. On the **Capabilities** tab, uncheck **Enable recommended alerts**, review the default settings. If prompted, accept the default **Azure Monitor workspace** and **Log Analytics workspace** values.
 
 1. Select the **Review + enable** tab, and then select **Enable**.
 


### PR DESCRIPTION
Lab01-configure-vms.md Ubuntu Server 20.04 LTS - x64 Gen2 is not available anymore
Lab02-monitor-vms.md On the **Capabilities** tab, uncheck **Enable recommended alerts**. With out uncheck **Enable recommended alerts**, it will ask for managed identity which will also block lab